### PR TITLE
Fix menu meta update

### DIFF
--- a/src/dashboard/class-menu-options.php
+++ b/src/dashboard/class-menu-options.php
@@ -103,7 +103,7 @@ if ( ! class_exists( 'Menu_Options' ) ) :
 			if ( isset( $data[ $item_id ] ) ) {
 				update_post_meta( $item_id, self::$key, $data[ $item_id ] );
 			} else {
-				delete_post_meta( $item_id, self::$key, '' );
+				delete_post_meta( $item_id, self::$key );
 			}
 		}
 


### PR DESCRIPTION
This PR proposes a fix for the `Menu Options` snippet where the post meta is not updated properly if the `$item_id` cannot be found in the `POST`.

An example for this issue was noticed when adding a checkbox input that, when checked and saved it would persist, but when unchecking it the update would fail.

Please let me know if this approach is correct or if I should adjust it.