### PR TITLE
Display plural label for the post-type archive breadcrumb 🍞 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@sixach/wp-snippets",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixach/wp-snippets",
-			"version": "1.4.2",
+			"version": "1.4.3",
 			"license": "GPL-3.0-or-later",
 			"devDependencies": {
-				"@wordpress/scripts": "19.2.1",
+				"@wordpress/scripts": "^19.2.2",
 				"husky": "^7.0.4",
 				"lint-staged": "12.0.2"
 			}
@@ -3475,9 +3475,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.3.tgz",
-			"integrity": "sha512-dL6xsQUeCNY7oqNDbbO9k65bOXq4zKwFfdJQITXUIuH3PBVoZaonsndeV8BsRs7I5YXiJCqT1ts6gjibJr914g==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.4.tgz",
+			"integrity": "sha512-qXiIhWLdTHWxBWawcqigJUUMeb2jkn9ElUEUC/Cn3DK2i62jiUWXOLp6tFIaf5eQMNXsYqtp5r7n2F/OllngQA==",
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
@@ -3658,12 +3658,12 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.4.tgz",
-			"integrity": "sha512-YFoV+rtBgoWYnW82iQCL5BwYzDPEE0aVNs33IkKV5X+eu7w730q+nyN7th+N4DOYdgApCgi9At2LLMAqTDtwwQ==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.5.tgz",
+			"integrity": "sha512-R+UKnjSJivvVEZ8rhGrXxsj/BlVeNO2FRXq3IxEOPv5ZRfAS0g8k8EO3xsCIV1RfnozvAApkKEYRClDYXIt+vA==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/base-styles": "^4.0.3",
+				"@wordpress/base-styles": "^4.0.4",
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
@@ -3680,9 +3680,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "19.2.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.1.tgz",
-			"integrity": "sha512-BIdCeCwPGQDlkfOR4THcxdiGMK7l27qbv1/n8OkqUcdDi9GICm3TnWeqzRgpw45j6GK0OCEvSjSjQi65kV1/Dw==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.2.tgz",
+			"integrity": "sha512-cH1NVhBKScNHIHXc3Af7FBOdsZBrA72IJVcZwUx79/BJVEhPVG3B9Kn4xkXP9RtYCkWETQ+s/KodzolL9RuHmQ==",
 			"dev": true,
 			"dependencies": {
 				"@svgr/webpack": "^5.5.0",
@@ -3692,7 +3692,7 @@
 				"@wordpress/eslint-plugin": "^9.3.0",
 				"@wordpress/jest-preset-default": "^7.1.3",
 				"@wordpress/npm-package-json-lint-config": "^4.1.0",
-				"@wordpress/postcss-plugins-preset": "^3.2.4",
+				"@wordpress/postcss-plugins-preset": "^3.2.5",
 				"@wordpress/prettier-config": "^1.1.1",
 				"@wordpress/stylelint-config": "^19.1.0",
 				"babel-jest": "^26.6.3",
@@ -20634,9 +20634,9 @@
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.3.tgz",
-			"integrity": "sha512-dL6xsQUeCNY7oqNDbbO9k65bOXq4zKwFfdJQITXUIuH3PBVoZaonsndeV8BsRs7I5YXiJCqT1ts6gjibJr914g==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.4.tgz",
+			"integrity": "sha512-qXiIhWLdTHWxBWawcqigJUUMeb2jkn9ElUEUC/Cn3DK2i62jiUWXOLp6tFIaf5eQMNXsYqtp5r7n2F/OllngQA==",
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
@@ -20758,12 +20758,12 @@
 			"requires": {}
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.4.tgz",
-			"integrity": "sha512-YFoV+rtBgoWYnW82iQCL5BwYzDPEE0aVNs33IkKV5X+eu7w730q+nyN7th+N4DOYdgApCgi9At2LLMAqTDtwwQ==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.5.tgz",
+			"integrity": "sha512-R+UKnjSJivvVEZ8rhGrXxsj/BlVeNO2FRXq3IxEOPv5ZRfAS0g8k8EO3xsCIV1RfnozvAApkKEYRClDYXIt+vA==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^4.0.3",
+				"@wordpress/base-styles": "^4.0.4",
 				"autoprefixer": "^10.2.5"
 			}
 		},
@@ -20774,9 +20774,9 @@
 			"dev": true
 		},
 		"@wordpress/scripts": {
-			"version": "19.2.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.1.tgz",
-			"integrity": "sha512-BIdCeCwPGQDlkfOR4THcxdiGMK7l27qbv1/n8OkqUcdDi9GICm3TnWeqzRgpw45j6GK0OCEvSjSjQi65kV1/Dw==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.2.tgz",
+			"integrity": "sha512-cH1NVhBKScNHIHXc3Af7FBOdsZBrA72IJVcZwUx79/BJVEhPVG3B9Kn4xkXP9RtYCkWETQ+s/KodzolL9RuHmQ==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.5.0",
@@ -20786,7 +20786,7 @@
 				"@wordpress/eslint-plugin": "^9.3.0",
 				"@wordpress/jest-preset-default": "^7.1.3",
 				"@wordpress/npm-package-json-lint-config": "^4.1.0",
-				"@wordpress/postcss-plugins-preset": "^3.2.4",
+				"@wordpress/postcss-plugins-preset": "^3.2.5",
 				"@wordpress/prettier-config": "^1.1.1",
 				"@wordpress/stylelint-config": "^19.1.0",
 				"babel-jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixach/wp-snippets",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "A plugin containing factory classes and methods for sixa projects.",
 	"keywords": [
 		"factory",
@@ -33,7 +33,7 @@
 		]
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "19.2.1",
+		"@wordpress/scripts": "^19.2.2",
 		"husky": "^7.0.4",
 		"lint-staged": "12.0.2"
 	}

--- a/src/frontend/class-breadcrumb.php
+++ b/src/frontend/class-breadcrumb.php
@@ -4,7 +4,7 @@
  *
  * @link          https://sixa.ch
  * @author        sixa AG
- * @since         1.0.0
+ * @since         1.4.3
  *
  * @package       Sixa_Snippets
  * @subpackage    Sixa_Snippets/Frontend
@@ -165,6 +165,8 @@ if ( ! class_exists( 'Breadcrumb' ) ) :
 		/**
 		 * Single post trail.
 		 *
+		 * @since     1.4.3
+		 *            Display the general name for the post type, usually plural.
 		 * @since     1.0.0
 		 * @param     int       $post_id      Post ID.
 		 * @param     string    $permalink    Post permalink.
@@ -202,7 +204,7 @@ if ( ! class_exists( 'Breadcrumb' ) ) :
 				$post_type = get_post_type_object( get_post_type( $post ) );
 
 				if ( ! empty( $post_type->has_archive ) ) {
-					$this->add_crumb( $post_type->labels->singular_name, get_post_type_archive_link( get_post_type( $post ) ) );
+					$this->add_crumbs_post_type_archive( $post );
 				}
 			} else {
 				$page_for_posts = get_option( 'page_for_posts', false );
@@ -304,14 +306,17 @@ if ( ! class_exists( 'Breadcrumb' ) ) :
 		/**
 		 * Post type archive trail.
 		 *
+		 * @since     1.4.3
+		 *            Optionally, provide a post-object as an argument.
 		 * @since     1.0.0
+		 * @param     null|object    $post    Post object.
 		 * @return    void
 		 */
-		protected function add_crumbs_post_type_archive() {
-			$post_type = get_post_type_object( get_post_type() );
+		protected function add_crumbs_post_type_archive( $post = null ) {
+			$post_type = get_post_type_object( get_post_type( $post ) );
 
 			if ( $post_type ) {
-				$this->add_crumb( $post_type->labels->name, get_post_type_archive_link( get_post_type() ) );
+				$this->add_crumb( $post_type->labels->name, get_post_type_archive_link( get_post_type( $post ) ) );
 			}
 		}
 


### PR DESCRIPTION
This PR replaces the singular label for the post-type archive in a single post view template with the general name for the post type, usually plural instead.