### PR TITLE
Ignore WooCommerce.Commenting.CommentHooks.MissingHooksComment

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,7 +45,9 @@
         <exclude name="Core.Commenting.CommentTags.AuthorTag" />
         <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType" />
     </rule>
-    <rule ref="WooCommerce-Core" />
+    <rule ref="WooCommerce-Core">
+        <exclude name="WooCommerce.Commenting.CommentHooks.MissingHooksComment" />
+    </rule>
     <!-- Let's also check that everything is properly documented. -->
     <rule ref="WordPress-Docs" />
     <!--

--- a/src/frontend/class-related-posts.php
+++ b/src/frontend/class-related-posts.php
@@ -76,7 +76,6 @@ if ( ! class_exists( 'Related_Posts' ) ) :
 
 					foreach ( $get_posts as $post ) {
 						$return .= sprintf( '<li class="%s">', implode( ' ', get_post_class( '', $post ) ) );
-						// Enable content to be added before the post.
 						$return .= apply_filters( 'sixa_related_posts_before_post', __return_empty_string(), $post );
 
 						// Thumbnail.
@@ -114,7 +113,6 @@ if ( ! class_exists( 'Related_Posts' ) ) :
 							$return .= sprintf( esc_html__( '%1$sRead more%2$s', 'sixa-snippets' ), sprintf( '<a href="%s">', esc_url( get_permalink( $post ) ) ), '</a>' );
 						}
 
-						// Enable content to be added after the post.
 						$return .= apply_filters( 'sixa_related_posts_after_post', __return_empty_string(), $post );
 						$return .= '</li>';
 					}
@@ -145,7 +143,6 @@ if ( ! class_exists( 'Related_Posts' ) ) :
 
 			$args = wp_parse_args(
 				$args,
-				// Enable Related Posts query arguments to be modified.
 				apply_filters(
 					'sixa_related_posts_query_args',
 					array(
@@ -171,7 +168,6 @@ if ( ! class_exists( 'Related_Posts' ) ) :
 			}
 
 			return get_posts(
-				// Enable Related Posts query arguments to be modified.
 				apply_filters(
 					'sixa_related_posts_query_args',
 					array(

--- a/src/frontend/class-related-posts.php
+++ b/src/frontend/class-related-posts.php
@@ -76,6 +76,7 @@ if ( ! class_exists( 'Related_Posts' ) ) :
 
 					foreach ( $get_posts as $post ) {
 						$return .= sprintf( '<li class="%s">', implode( ' ', get_post_class( '', $post ) ) );
+						// Enable content to be added before the post.
 						$return .= apply_filters( 'sixa_related_posts_before_post', __return_empty_string(), $post );
 
 						// Thumbnail.
@@ -113,6 +114,7 @@ if ( ! class_exists( 'Related_Posts' ) ) :
 							$return .= sprintf( esc_html__( '%1$sRead more%2$s', 'sixa-snippets' ), sprintf( '<a href="%s">', esc_url( get_permalink( $post ) ) ), '</a>' );
 						}
 
+						// Enable content to be added after the post.
 						$return .= apply_filters( 'sixa_related_posts_after_post', __return_empty_string(), $post );
 						$return .= '</li>';
 					}
@@ -143,6 +145,7 @@ if ( ! class_exists( 'Related_Posts' ) ) :
 
 			$args = wp_parse_args(
 				$args,
+				// Enable Related Posts query arguments to be modified.
 				apply_filters(
 					'sixa_related_posts_query_args',
 					array(
@@ -168,6 +171,7 @@ if ( ! class_exists( 'Related_Posts' ) ) :
 			}
 
 			return get_posts(
+				// Enable Related Posts query arguments to be modified.
 				apply_filters(
 					'sixa_related_posts_query_args',
 					array(


### PR DESCRIPTION
[In version 0.1.2, woocommerce-sniffs introduced a new sniff `WooCommerce.Commenting.CommentHooks.MissingHooksComment`](https://github.com/woocommerce/woocommerce-sniffs/blob/trunk/CHANGELOG.md). The rule proposes to add comments to all instances of `apply_filters` and `do_action` to describe what the hooks are doing.

I haven't found any examples in the WooCommerce source code. Nevertheless, I've been adding comments to our codebase and after a few files, I figured that in most instances, the comment is mostly a duplicate of the name of the filter (and the surrounding code). For instance

```PHP
// In class-related-posts.php

// Enable the content before the post to be modified.
$return .= apply_filters( 'sixa_related_posts_before_post', __return_empty_string(), $post );

// Enable the content after the post to be modified.
$return .= apply_filters( 'sixa_related_posts_after_post', __return_empty_string(), $post );

// In class-contact-info.php

/**
 * Generate a Google Maps link for the supplied address.
 *
 * @since     1.0.0
 * @param     string    $address    The URL to encode.
 * @return    string
 */
public static function get_map_link( $address ) {
    // Enable the Google Maps link to be modified.
    return apply_filters( 'sixa_contact_info_widget_map_link', sprintf( 'https://maps.google.com/maps?z=16&q=%s', self::do_urlencode_address( $address ) ) );
}
```

thus, personally, I do not see any added values (considering the overhead) in making these comments and would propose to ignore this rule.

Please share your thoughts.