### PR TITLE
Generate wrapper columns attributes

### DIFF
--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -542,7 +542,7 @@ if ( ! class_exists( Utils::class ) ) :
 		 * Returns a list of Columns (breakpoint) CSS class names along with
 		 * the inline CSS style for the gap range defined viewport-wide.
 		 *
-		 * @since     1.0.0
+		 * @since     1.7.0
 		 * @param     array $attributes    Available block attributes and their corresponding values.
 		 * @return    array
 		 */


### PR DESCRIPTION
This PR essentially mimicks and brings the equivalent functionality of the [useColumnsProps](https://github.com/sixach/wp-react-hooks/blob/main/src/useColumnsProps/index.js) react hook from the JavaScript package into PHP mainly for the front-end rendering of the blocks with support for responsive columns and gap definition across different viewports.