### PR TITLE
Extend XML Entity Normalization

### DIFF
--- a/languages/sixa-snippets.pot
+++ b/languages/sixa-snippets.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sixa Snippets 1.0.0\n"
+"Project-Id-Version: Sixa Snippets 1.7.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sixa-wp-snippets\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-01-31T13:18:44+00:00\n"
+"POT-Creation-Date: 2022-04-08T15:20:33+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: sixa-snippets\n"
@@ -73,160 +73,160 @@ msgctxt "post type"
 msgid "Posts"
 msgstr ""
 
-#: src/dashboard/class-post-type.php:140
+#: src/dashboard/class-post-type.php:141
 msgctxt "post type"
 msgid "Add new"
 msgstr ""
 
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:142
+#: src/dashboard/class-post-type.php:143
 msgctxt "post type"
 msgid "All %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:144
+#: src/dashboard/class-post-type.php:145
 msgctxt "post type"
 msgid "Add new %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:146
+#: src/dashboard/class-post-type.php:147
 msgctxt "post type"
 msgid "Edit %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:148
+#: src/dashboard/class-post-type.php:149
 msgctxt "post type"
 msgid "New %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:150
-#: src/dashboard/class-post-type.php:152
+#: src/dashboard/class-post-type.php:151
+#: src/dashboard/class-post-type.php:153
 msgctxt "post type"
 msgid "View %1$s"
 msgstr ""
 
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:154
+#: src/dashboard/class-post-type.php:155
 msgctxt "post type"
 msgid "Search %1$s"
 msgstr ""
 
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:156
+#: src/dashboard/class-post-type.php:157
 msgctxt "post type"
 msgid "No %1$s found"
 msgstr ""
 
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:158
+#: src/dashboard/class-post-type.php:159
 msgctxt "post type"
 msgid "No %1$s found in trash"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:160
-#: src/dashboard/class-post-type.php:194
+#: src/dashboard/class-post-type.php:161
+#: src/dashboard/class-post-type.php:195
 msgctxt "post type"
 msgid "Parent %1$s:"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:162
+#: src/dashboard/class-post-type.php:163
 msgctxt "post type"
 msgid "Featured image for this %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:164
+#: src/dashboard/class-post-type.php:165
 msgctxt "post type"
 msgid "Set featured image for this %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:166
+#: src/dashboard/class-post-type.php:167
 msgctxt "post type"
 msgid "Remove featured image for this %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:168
+#: src/dashboard/class-post-type.php:169
 msgctxt "post type"
 msgid "Use as featured image for this %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:170
+#: src/dashboard/class-post-type.php:171
 msgctxt "post type"
 msgid "%1$s archives"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:172
+#: src/dashboard/class-post-type.php:173
 msgctxt "post type"
 msgid "Insert into %1$s"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:174
+#: src/dashboard/class-post-type.php:175
 msgctxt "post type"
 msgid "Upload to this %1$s"
 msgstr ""
 
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:176
+#: src/dashboard/class-post-type.php:177
 msgctxt "post type"
 msgid "Filter %1$s list"
 msgstr ""
 
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:178
+#: src/dashboard/class-post-type.php:179
 msgctxt "post type"
 msgid "%1$s list navigation"
 msgstr ""
 
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:180
+#: src/dashboard/class-post-type.php:181
 msgctxt "post type"
 msgid "%1$s list"
 msgstr ""
 
 #. translators: %1$s: General name for the post type, usually plural.
-#: src/dashboard/class-post-type.php:182
+#: src/dashboard/class-post-type.php:183
 msgctxt "post type"
 msgid "%1$s attributes"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:184
+#: src/dashboard/class-post-type.php:185
 msgctxt "post type"
 msgid "%1$s published"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:186
+#: src/dashboard/class-post-type.php:187
 msgctxt "post type"
 msgid "%1$s published privately."
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:188
+#: src/dashboard/class-post-type.php:189
 msgctxt "post type"
 msgid "%1$s reverted to draft."
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:190
+#: src/dashboard/class-post-type.php:191
 msgctxt "post type"
 msgid "%1$s scheduled"
 msgstr ""
 
 #. translators: %1$s: Name for one object of this post type.
-#: src/dashboard/class-post-type.php:192
+#: src/dashboard/class-post-type.php:193
 msgctxt "post type"
 msgid "%1$s updated."
 msgstr ""
@@ -236,114 +236,114 @@ msgctxt "reading"
 msgid "Additional Settings"
 msgstr ""
 
-#: src/dashboard/class-taxonomy.php:59
+#: src/dashboard/class-taxonomy.php:61
 msgctxt "taxonomy"
 msgid "Category"
 msgstr ""
 
-#: src/dashboard/class-taxonomy.php:60
+#: src/dashboard/class-taxonomy.php:62
 msgctxt "taxonomy"
 msgid "Categories"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:103
+#: src/dashboard/class-taxonomy.php:107
 msgctxt "taxonomy"
 msgid "All %s"
 msgstr ""
 
 #. translators: %s: Name for one object of this taxonomy type.
-#: src/dashboard/class-taxonomy.php:105
+#: src/dashboard/class-taxonomy.php:109
 msgctxt "taxonomy"
 msgid "Edit %s"
 msgstr ""
 
 #. translators: %s: Name for one object of this taxonomy type.
-#: src/dashboard/class-taxonomy.php:107
+#: src/dashboard/class-taxonomy.php:111
 msgctxt "taxonomy"
 msgid "View %s"
 msgstr ""
 
 #. translators: %s: Name for one object of this taxonomy type.
-#: src/dashboard/class-taxonomy.php:109
+#: src/dashboard/class-taxonomy.php:113
 msgctxt "taxonomy"
 msgid "Update %s name"
 msgstr ""
 
 #. translators: %s: Name for one object of this taxonomy type.
-#: src/dashboard/class-taxonomy.php:111
+#: src/dashboard/class-taxonomy.php:115
 msgctxt "taxonomy"
 msgid "Add new %s"
 msgstr ""
 
 #. translators: %s: Name for one object of this taxonomy type.
-#: src/dashboard/class-taxonomy.php:113
+#: src/dashboard/class-taxonomy.php:117
 msgctxt "taxonomy"
 msgid "New %s name"
 msgstr ""
 
 #. translators: %s: Name for one object of this taxonomy type.
-#: src/dashboard/class-taxonomy.php:115
+#: src/dashboard/class-taxonomy.php:119
 msgctxt "taxonomy"
 msgid "Parent %s"
 msgstr ""
 
 #. translators: %s: Name for one object of this taxonomy type.
-#: src/dashboard/class-taxonomy.php:117
+#: src/dashboard/class-taxonomy.php:121
 msgctxt "taxonomy"
 msgid "Parent %s:"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:119
+#: src/dashboard/class-taxonomy.php:123
 msgctxt "taxonomy"
 msgid "Search %s"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:121
+#: src/dashboard/class-taxonomy.php:125
 msgctxt "taxonomy"
 msgid "Popular %s"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:123
+#: src/dashboard/class-taxonomy.php:127
 msgctxt "taxonomy"
 msgid "Separate %s with commas"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:125
+#: src/dashboard/class-taxonomy.php:129
 msgctxt "taxonomy"
 msgid "Add or remove %s"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:127
+#: src/dashboard/class-taxonomy.php:131
 msgctxt "taxonomy"
 msgid "Choose from the most used %s"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:129
+#: src/dashboard/class-taxonomy.php:133
 msgctxt "taxonomy"
 msgid "No %s found"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:131
+#: src/dashboard/class-taxonomy.php:135
 msgctxt "taxonomy"
 msgid "No %s"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:133
+#: src/dashboard/class-taxonomy.php:137
 msgctxt "taxonomy"
 msgid "%s list navigation"
 msgstr ""
 
 #. translators: %s: General name for the taxonomy type, usually plural.
-#: src/dashboard/class-taxonomy.php:135
+#: src/dashboard/class-taxonomy.php:139
 msgctxt "taxonomy"
 msgid "%s list"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixach/wp-snippets",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixach/wp-snippets",
-			"version": "1.7.2",
+			"version": "1.7.3",
 			"license": "GPL-3.0-or-later",
 			"devDependencies": {
 				"@wordpress/scripts": "22.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixach/wp-snippets",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"description": "A plugin containing factory classes and methods for sixa projects.",
 	"keywords": [
 		"factory",

--- a/sixa-snippets.php
+++ b/sixa-snippets.php
@@ -11,7 +11,7 @@
  * Plugin Name:          Sixa Snippets
  * Plugin URI:           https://sixa.ch
  * Description:          A plugin containing factory classes or methods for the Sixa projects.
- * Version:              1.7.2
+ * Version:              1.7.3
  * Requires at least:    5.3
  * Requires PHP:         7.4
  * Author:               sixa AG

--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -254,29 +254,29 @@ if ( ! class_exists( Utils::class ) ) :
 			 * List of pattern replacements corresponding to patterns searched.
 			 */
 			$plain_replace = array(
-				'&#KEEPAMP;',   // Ampersand.
-				'&#KEEPLT;',          // Less-than.
-				'',           // Non-legal carriage return.
-				' ',          // Non-breaking space.
-				'"',          // Double quotes.
-				"'",          // Single quotes.
-				'>',          // Greater-than.
-				'&#169;',     // Copyright.
-				'&#8482;',    // Trademark.
-				'&#174;',     // Registered.
-				'--',         // mdash.
-				'-',          // ndash.
-				'*',          // Bullet.
-				'£',          // Pound sign.
-				'€',          // Euro sign. € ?.
-				'$',          // Dollar sign.
-				'&#x192;',    // Function sign.
-				'&#xa5;',     // Yen sign.
-				'&#xa2;',     // Cent sign.
-				'&#xa4;',     // Currency sign.
-				'',           // Unknown/unhandled entities.
-				'&amp;',      // Add ampersand back.
-				' ',          // Runs of spaces, post-handling.
+				'&#KEEPAMP;',    // Ampersand.
+				'&#KEEPLT;',     // Less-than.
+				'',              // Non-legal carriage return.
+				' ',             // Non-breaking space.
+				'"',             // Double quotes.
+				"'",             // Single quotes.
+				'>',             // Greater-than.
+				'&#169;',        // Copyright.
+				'&#8482;',       // Trademark.
+				'&#174;',        // Registered.
+				'--',            // mdash.
+				'-',             // ndash.
+				'*',             // Bullet.
+				'£',             // Pound sign.
+				'€',             // Euro sign. € ?.
+				'$',             // Dollar sign.
+				'&#x192;',       // Function sign.
+				'&#xa5;',        // Yen sign.
+				'&#xa2;',        // Cent sign.
+				'&#xa4;',        // Currency sign.
+				'',              // Unknown/unhandled entities.
+				'&amp;',         // Add ampersand back.
+				' ',             // Runs of spaces, post-handling.
 			);
 
 			return preg_replace( $plain_search, $plain_replace, $input );

--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -248,6 +248,7 @@ if ( ! class_exists( Utils::class ) ) :
 				'/&curren;/i',                // Currency sign.
 				'/&[a-z]+;/i',                // Unknown/unhandled entities.
 				'/&#KEEPAMP;/i',              // Add ampersand back.
+				'/&#KEEPLT;/i',               // Add less-than back.
 				'/[ ]{2,}/',                  // Runs of spaces, post-handling.
 			);
 			/**
@@ -276,6 +277,7 @@ if ( ! class_exists( Utils::class ) ) :
 				'&#xa4;',        // Currency sign.
 				'',              // Unknown/unhandled entities.
 				'&amp;',         // Add ampersand back.
+				'&lt;',         // Add ampersand back.
 				' ',             // Runs of spaces, post-handling.
 			);
 

--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -263,7 +263,6 @@ if ( ! class_exists( Utils::class ) ) :
 				' ',             // Non-breaking space.
 				'"',             // Double quotes.
 				"'",             // Single quotes.
-				'>',             // Greater-than.
 				'&#169;',        // Copyright.
 				'&#8482;',       // Trademark.
 				'&#174;',        // Registered.

--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -228,11 +228,11 @@ if ( ! class_exists( Utils::class ) ) :
 			$plain_search = array(
 				'/&amp;/i',                   // Ampersand.
 				'/&lt;/i',                    // Less-than.
+				'/&gt;/i',                    // Greater-than.
 				"/\r/",                       // Non-legal carriage return.
 				'/&nbsp;/i',                  // Non-breaking space.
 				'/&(quot|rdquo|ldquo);/i',    // Double quotes.
 				'/&(apos|rsquo|lsquo);/i',    // Single quotes.
-				'/&gt;/i',                    // Greater-than.
 				'/&copy;/i',                  // Copyright.
 				'/&trade;/i',                 // Trademark.
 				'/&reg;/i',                   // Registered.
@@ -249,6 +249,7 @@ if ( ! class_exists( Utils::class ) ) :
 				'/&[a-z]+;/i',                // Unknown/unhandled entities.
 				'/&#KEEPAMP;/i',              // Add ampersand back.
 				'/&#KEEPLT;/i',               // Add less-than back.
+				'/&#KEEPGT;/i',               // Add less-than back.
 				'/[ ]{2,}/',                  // Runs of spaces, post-handling.
 			);
 			/**
@@ -257,6 +258,7 @@ if ( ! class_exists( Utils::class ) ) :
 			$plain_replace = array(
 				'&#KEEPAMP;',    // Ampersand.
 				'&#KEEPLT;',     // Less-than.
+				'&#KEEPGT;',     // Greater-than.
 				'',              // Non-legal carriage return.
 				' ',             // Non-breaking space.
 				'"',             // Double quotes.
@@ -277,7 +279,8 @@ if ( ! class_exists( Utils::class ) ) :
 				'&#xa4;',        // Currency sign.
 				'',              // Unknown/unhandled entities.
 				'&amp;',         // Add ampersand back.
-				'&lt;',         // Add ampersand back.
+				'&lt;',          // Add less-than back.
+				'&gt;',          // Add greater-than back.
 				' ',             // Runs of spaces, post-handling.
 			);
 

--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -212,6 +212,8 @@ if ( ! class_exists( Utils::class ) ) :
 		 * Also note that the list of named entities is far from complete and could be
 		 * extended in the future.
 		 *
+		 * @since     1.7.3
+		 *            Changed search & replace to keep all HTML entities that are valid in XML.
 		 * @since     1.4.2
 		 * @param     string $input    Given input string, text or HTML markup.
 		 * @return    string

--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -227,12 +227,12 @@ if ( ! class_exists( Utils::class ) ) :
 			 */
 			$plain_search = array(
 				'/&amp;/i',                   // Ampersand.
+				'/&lt;/i',                    // Less-than.
 				"/\r/",                       // Non-legal carriage return.
 				'/&nbsp;/i',                  // Non-breaking space.
 				'/&(quot|rdquo|ldquo);/i',    // Double quotes.
 				'/&(apos|rsquo|lsquo);/i',    // Single quotes.
 				'/&gt;/i',                    // Greater-than.
-				'/&lt;/i',                    // Less-than.
 				'/&copy;/i',                  // Copyright.
 				'/&trade;/i',                 // Trademark.
 				'/&reg;/i',                   // Registered.
@@ -255,12 +255,12 @@ if ( ! class_exists( Utils::class ) ) :
 			 */
 			$plain_replace = array(
 				'&#KEEPAMP;',   // Ampersand.
+				'&#KEEPLT;',          // Less-than.
 				'',           // Non-legal carriage return.
 				' ',          // Non-breaking space.
 				'"',          // Double quotes.
 				"'",          // Single quotes.
 				'>',          // Greater-than.
-				'<',          // Less-than.
 				'&#169;',     // Copyright.
 				'&#8482;',    // Trademark.
 				'&#174;',     // Registered.

--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -247,14 +247,14 @@ if ( ! class_exists( Utils::class ) ) :
 				'/&cent;/i',                  // Cent sign.
 				'/&curren;/i',                // Currency sign.
 				'/&[a-z]+;/i',                // Unknown/unhandled entities.
-				'/&#MYAMP;/i',                // Add ampersand back.
+				'/&#KEEPAMP;/i',              // Add ampersand back.
 				'/[ ]{2,}/',                  // Runs of spaces, post-handling.
 			);
 			/**
 			 * List of pattern replacements corresponding to patterns searched.
 			 */
 			$plain_replace = array(
-				'&#MYAMP;',   // Ampersand.
+				'&#KEEPAMP;',   // Ampersand.
 				'',           // Non-legal carriage return.
 				' ',          // Non-breaking space.
 				'"',          // Double quotes.

--- a/src/includes/class-utils.php
+++ b/src/includes/class-utils.php
@@ -226,13 +226,13 @@ if ( ! class_exists( Utils::class ) ) :
 			 * @see    https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML
 			 */
 			$plain_search = array(
+				'/&amp;/i',                   // Ampersand.
 				"/\r/",                       // Non-legal carriage return.
 				'/&nbsp;/i',                  // Non-breaking space.
 				'/&(quot|rdquo|ldquo);/i',    // Double quotes.
 				'/&(apos|rsquo|lsquo);/i',    // Single quotes.
 				'/&gt;/i',                    // Greater-than.
 				'/&lt;/i',                    // Less-than.
-				'/&amp;/i',                   // Ampersand.
 				'/&copy;/i',                  // Copyright.
 				'/&trade;/i',                 // Trademark.
 				'/&reg;/i',                   // Registered.
@@ -254,13 +254,13 @@ if ( ! class_exists( Utils::class ) ) :
 			 * List of pattern replacements corresponding to patterns searched.
 			 */
 			$plain_replace = array(
+				'&#MYAMP;',   // Ampersand.
 				'',           // Non-legal carriage return.
 				' ',          // Non-breaking space.
 				'"',          // Double quotes.
 				"'",          // Single quotes.
 				'>',          // Greater-than.
 				'<',          // Less-than.
-				'&#MYAMP;',   // Ampersand.
 				'&#169;',     // Copyright.
 				'&#8482;',    // Trademark.
 				'&#174;',     // Registered.


### PR DESCRIPTION
This PR extends the current version of `normalize_xml_character_entities` to keep all other HTML entities that are valid in XML (except `&quot;`) and includes the relevant maintenance changes to release a new version after merging.